### PR TITLE
Patched strange hidden keys getting displayed

### DIFF
--- a/yubikey-oath-dmenu
+++ b/yubikey-oath-dmenu
@@ -62,8 +62,10 @@ def touch_callback(ctx):
               help='Provide feedback via notify-send')
 @click.option('--type', 'typeit', default=False, is_flag=True,
               help='Type code using xdotool instead of copying to clipboard')
+@click.option('--no-hidden', 'no_hidden', default=False, is_flag=True,
+              help='Hide _hidden credentials')
 @click.version_option(version=VERSION)
-def cli(ctx, clipboard, notify_enable, typeit):
+def cli(ctx, clipboard, notify_enable, typeit, no_hidden):
     '''
     Select an OATH credential on your YubiKey using dmenu, then copy the
     corresponding OTP to the clipboard using xclip.
@@ -78,7 +80,7 @@ def cli(ctx, clipboard, notify_enable, typeit):
 
     credentials = {
         k: {cred.printable_key: cred
-            for cred in ctrl.list() if not cred.printable_key.startswith("_")
+            for cred in ctrl.list() if not (no_hidden and cred.printable_key.startswith("_hidden"))
             }
         for k, ctrl in controllers.items()
     }

--- a/yubikey-oath-dmenu
+++ b/yubikey-oath-dmenu
@@ -65,7 +65,7 @@ def touch_callback(ctx):
 @click.option('--type', 'typeit', default=False, is_flag=True,
               help='Type code using xdotool instead of copying to clipboard')
 @click.version_option(version=VERSION)
-def cli(ctx, clipboard, notify_enable, typeit, no_hidden):
+def cli(ctx, clipboard, notify_enable, no_hidden, typeit):
     '''
     Select an OATH credential on your YubiKey using dmenu, then copy the
     corresponding OTP to the clipboard using xclip.

--- a/yubikey-oath-dmenu
+++ b/yubikey-oath-dmenu
@@ -58,12 +58,12 @@ def touch_callback(ctx):
 @click.option('--clipboard', metavar='CLIPBOARD',
               help='Passed through as -selection option to xclip')
 @click.help_option('-h', '--help')
+@click.option('--no-hidden', 'no_hidden', default=False, is_flag=True,
+              help='Hide _hidden credentials')
 @click.option('--notify', 'notify_enable', default=False, is_flag=True,
               help='Provide feedback via notify-send')
 @click.option('--type', 'typeit', default=False, is_flag=True,
               help='Type code using xdotool instead of copying to clipboard')
-@click.option('--no-hidden', 'no_hidden', default=False, is_flag=True,
-              help='Hide _hidden credentials')
 @click.version_option(version=VERSION)
 def cli(ctx, clipboard, notify_enable, typeit, no_hidden):
     '''

--- a/yubikey-oath-dmenu
+++ b/yubikey-oath-dmenu
@@ -78,7 +78,7 @@ def cli(ctx, clipboard, notify_enable, typeit):
 
     credentials = {
         k: {cred.printable_key: cred
-            for cred in ctrl.list()
+            for cred in ctrl.list() if not cred.printable_key.startswith("_")
             }
         for k, ctrl in controllers.items()
     }


### PR DESCRIPTION
I don't know if this is intended, but I always got some keys displayed with an underscore in front (maybe something internal of the oath?). These didn't seem to have any functionality to me so I just patched it to hide them.