### PR TITLE
Allow arbitrary clipboard commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ yubikey-oath-dmenu
 [dmenu][] interface for getting OATH codes from a [YubiKey][]
 
 This program lets you pick an OATH credential from your YubiKey using [dmenu][],
-and copies the corresponding OTP to the clipboard using [xclip][].
-Alternatively, it can "type" the OTP using [xdotool][] on X11 or [wtype][]
-on Wayland.
+and writes the OTP to stdout.
+Alternatively, it can copy the OTP to a clipboard tool or "type" the OTP using [xdotool][] on X11
+or [wtype][] on Wayland.
 
 Notable features:
 
@@ -27,7 +27,7 @@ window manager or desktop environment. For example, you could bind it to
 in [i3wm][] like this:
 
     # Grab OTPs from ykman oath
-    bindsym $mod+o exec yubikey-oath-dmenu --notify --clipboard clipboard
+    bindsym $mod+o exec yubikey-oath-dmenu --notify --clipboard "xclip -selection clipboard"
     bindsym $mod+Shift+o exec yubikey-oath-dmenu --notify --type -p "Credential to type:"
 
 
@@ -37,7 +37,6 @@ Dependencies
 - [Python 3][python]
 - [Click][click]
 - [dmenu][]
-- [xclip][]
 - [YubiKey Manager Python library][ykman], version 0.5.0 or later.
 
 Optional dependencies:
@@ -46,6 +45,7 @@ Optional dependencies:
 - [pinentry][]: To prompt for the YubiKey OATH password when needed
 - [xdotool][]: For the `--type` option under X11
 - [wtype][]: For the `--type` option under Wayland (`xdotool` might also work)
+- a clipboard tool: For the `--clipboard` option, such as [xclip][] or [wl-clipboard][]
 
 
 Installation
@@ -79,6 +79,7 @@ Installation
 [libnotify]: https://developer.gnome.org/libnotify/
 [pinentry]: https://www.gnupg.org/related_software/pinentry/index.html
 [python]: https://www.python.org/
+[wl-clipboard]: https://github.com/bugaevc/wl-clipboard
 [wtype]: https://github.com/atx/wtype
 [xclip]: https://linux.die.net/man/1/xclip
 [xdotool]: http://www.semicomplete.com/projects/xdotool/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ yubikey-oath-dmenu
 [dmenu][] interface for getting OATH codes from a [YubiKey][]
 
 This program lets you pick an OATH credential from your YubiKey using [dmenu][],
-and writes the OTP to stdout.
-Alternatively, it can copy the OTP to a clipboard tool or "type" the OTP using [xdotool][] on X11
-or [wtype][] on Wayland.
+and copies the corresponding OTP to the clipboard.
+Alternatively, it can "type" the OTP using [xdotool][] on X11 or [wtype][]
+on Wayland.
 
 Notable features:
 
@@ -27,7 +27,8 @@ window manager or desktop environment. For example, you could bind it to
 in [i3wm][] like this:
 
     # Grab OTPs from ykman oath
-    bindsym $mod+o exec yubikey-oath-dmenu --notify --clipboard "xclip -selection clipboard"
+    bindsym $mod+o exec yubikey-oath-dmenu --notify --clipboard clipboard
+    bindsym $mod+o exec yubikey-oath-dmenu --notify --clipboard-cmd "wl-copy --paste-once"
     bindsym $mod+Shift+o exec yubikey-oath-dmenu --notify --type -p "Credential to type:"
 
 
@@ -37,6 +38,7 @@ Dependencies
 - [Python 3][python]
 - [Click][click]
 - [dmenu][]
+- [xclip][]
 - [YubiKey Manager Python library][ykman], version 0.5.0 or later.
 
 Optional dependencies:
@@ -44,8 +46,8 @@ Optional dependencies:
 - [libnotify][]: For the `--notify` option, which uses `notify-send`
 - [pinentry][]: To prompt for the YubiKey OATH password when needed
 - [xdotool][]: For the `--type` option under X11
+- [wl-clipboard][]: Can be used for the `--clipboard-cmd` option
 - [wtype][]: For the `--type` option under Wayland (`xdotool` might also work)
-- a clipboard tool: For the `--clipboard` option, such as [xclip][] or [wl-clipboard][]
 
 
 Installation

--- a/yubikey-oath-dmenu.py
+++ b/yubikey-oath-dmenu.py
@@ -113,8 +113,10 @@ def verify_password(oath_controller, password):
 
 @click.command(context_settings=dict(ignore_unknown_options=True))
 @click.pass_context
-@click.option('--clipboard', metavar='CLIPBOARD', default=False,
-              help='Passed as clipboard command')
+@click.option('--clipboard', metavar='CLIPBOARD',
+              help='Passed through as -selection option to xclip; ignored if --clipboard-cmd is given')
+@click.option('--clipboard-cmd', metavar='CLIPBOARD_CMD',
+              help='Copy-to-clipboard command to use instead of xclip')
 @click.option('--dmenu-prompt', 'dmenu_prompt', metavar='PROMPT', default = 'Credentials:',
               help='Passed as -p argument to dmenu')
 @click.help_option('-h', '--help')
@@ -128,10 +130,10 @@ def verify_password(oath_controller, password):
               help='Type code instead of copying to clipboard')
 @click.argument('dmenu_args', nargs=-1, type=click.UNPROCESSED)
 @click.version_option(version=VERSION)
-def cli(ctx, clipboard, dmenu_prompt, notify_enable, no_hidden, pinentry_program, typeit, dmenu_args):
+def cli(ctx, clipboard, clipboard_cmd, dmenu_prompt, notify_enable, no_hidden, pinentry_program, typeit, dmenu_args):
     '''
-    Select an OATH credential on your YubiKey using dmenu, then write the
-    corresponding OTP to stdout.
+    Select an OATH credential on your YubiKey using dmenu, then copy the
+    corresponding OTP to the clipboard.
 
     Unknown options and arguments are passed through to dmenu.
     '''
@@ -205,9 +207,12 @@ def cli(ctx, clipboard, dmenu_prompt, notify_enable, no_hidden, pinentry_program
 
         if typeit_cmd:
             subprocess.run(typeit_cmd + [code])
-        elif clipboard:
+        else:
+            clip_cmd = shlex.split('xclip' if clipboard_cmd is None else clipboard_cmd)
+            if clipboard_cmd is None and clipboard is not None:
+                clip_cmd += ['-selection', clipboard]
             clip_proc = subprocess.Popen(
-                shlex.split(clipboard),
+                clip_cmd,
                 stdin=subprocess.PIPE,
                 encoding='utf-8'
             )
@@ -215,8 +220,6 @@ def cli(ctx, clipboard, dmenu_prompt, notify_enable, no_hidden, pinentry_program
             msg = 'OTP copied to clipboard: %s' % selected_cred_id
             click.echo(msg)
             notify(msg)
-        else:
-            print(code)
 
     else:
         click.echo('Aborted by user.')


### PR DESCRIPTION
`xclip` doesn't work under wayland. Instead of adding `wl-clipboard` as alternative, I decided to allow arbitrary commands as command line arguments.

To support arbitrary clipboard tools, the `--clipboard` command line argument has been extended to accept custom commands. Since the `--clipboard` argument is now optional, the default behavior is to write the OTP to stdout.